### PR TITLE
Fix for API Throttling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-xdr",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "./integration.js",
   "name": "cortex-xdr",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "license": "MIT",
   "author": "Polarity",

--- a/server/request.js
+++ b/server/request.js
@@ -17,6 +17,7 @@ const requestWithDefaults = createRequestWithDefaults({
   preprocessRequestOptions: ({ options, route, ...requestOptions }) => {
     return {
       ...requestOptions,
+      options,
       url: `${options.url}/public_api/v1/${route}`,
       headers: {
         Authorization: options.apiKey,


### PR DESCRIPTION
API Request Throttling is not working with the correct numbers, as the utils lib uses the `options` in the requestOptions for the parameters for bottleneck throttling.  This fix will make it so the default throttling isn't used anymore, but instead the correct throttling outlined in the `integration.js` file used.